### PR TITLE
Update How to find the default user of an image.html

### DIFF
--- a/How to find the default user of an image.html
+++ b/How to find the default user of an image.html
@@ -11,13 +11,17 @@
 Click on the Image Name of your instance</li>
 <li>Look under the “Custom Properties” section for “default_user” (this will
 only work for ephemeral instances)</li>
+<li>If your instance uses a volume boot disk, scroll down the the "Volumes
+Attached" section and click on the boot volume (usually identified as "on /dev/vda").</li>
+<li>Next you have to scroll to the "Volume Source" section and click on the image.</li>
+<li>From here you can look under the “Custom Properties” section for “default_user”.</li>
 </ol>
 </div>
 <div id="dreamhost-cloud-control-panel">
 <h2><a class="reference external" href="http://cloud.dreamhost.com/">DreamHost Cloud Control Panel</a></h2>
 <ol class="arabic simple">
 <li>Click on the instance name that you want to know the default user of.</li>
-<li>Look under the “SSH Login” section for “<strong>ssh $user@$ip</strong>”, the username is
+<li>Click on "Access" and then look under the “SSH Login” section for “<strong>ssh $user@$ip</strong>”, the username is
 found before the “@” in that command.</li>
 </ol>
 <p>The default user is the user you can use to login with the public key that you


### PR DESCRIPTION
Horizon (iad2.dreamcompute.com) and Sunrise (cloud.dreamhost.com) have changed a bit since this was last updated, so I've tried to update the language for how to find the default user. Also added instructions for locating the default user for a volume-based instance.