### PR TITLE
Update PHP with Nginx at DreamHost.html

### DIFF
--- a/PHP with Nginx at DreamHost.html
+++ b/PHP with Nginx at DreamHost.html
@@ -7,7 +7,7 @@
 <div class="alert alert-note">
 <div class="alert-icon"><img src="https://objects-us-west-1.dream.io/kbimages/images/dh-kb-note-icon.svg" alt="" width="60" height="60" /></div>
 <div class="alert-content">
-<p>PHP 5.6 is the only version available in the panel to use with your Nginx website.</p>
+<p>PHP 5.5 is the only version available in the panel to use with your Nginx website.</p>
 </div>
 </div>
 <h2><span id="PHP_processes_per_user">PHP processes per user</span></h2>


### PR DESCRIPTION
This article looks to have been an innocent victim of mass updates related to the PHP 5.5 EOL. nginx _only_ offers PHP 5.5, so in my opinion this article should reflect that (until such time as managed nginx is either completely removed or updated to PHP 5.6).