### PR TITLE
Update PHP 7 overview.html

### DIFF
--- a/PHP 7 overview.html
+++ b/PHP 7 overview.html
@@ -65,7 +65,7 @@
 <li><a href="https://wiki.php.net/rfc/php6">https://wiki.php.net/rfc/php6</a></li>
 </ul>
 <h3><span id="Is_PHP_7_available_on_Nginx_machines.3F">Is PHP 7 available on Nginx machines?</span></h3>
-<p>No. Current, only PHP 5.6 is available.</p>
+<p>No. Currently, only PHP 5.5 is available.</p>
 <h2><span id="Troubleshooting">Troubleshooting</span></h2>
 <h3><span id="My_site_will_not_connect_to_my_database_after_upgrading_to_PHP_7">My site will not connect to my database after upgrading to PHP 7</span></h3>
 <p>Previous versions of PHP offered three PHP APIs for accessing a MySQL database. They were:</p>


### PR DESCRIPTION
This article looks to have been an innocent victim of mass updates related to the PHP 5.5 EOL. nginx only offers PHP 5.5, so in my opinion this article should reflect that (until such time as managed nginx is either completely removed or updated to PHP 5.6).