### PR TITLE
Update Updating PHP for Dedicated servers.html

### DIFF
--- a/Updating PHP for Dedicated servers.html
+++ b/Updating PHP for Dedicated servers.html
@@ -1,6 +1,6 @@
 <h2>Dedicated Non-Admin Apache users</h2>
 <ul>
-<li>Non-Admin Nginx users were automatically updated to PHP 5.6 on March 14 2017.</li>
+<li>Non-Admin Apache users were automatically updated to PHP 5.6 on March 14 2017.</li>
 <li>Please see the <a href="/hc/en-us/articles/214895317-How-do-I-change-the-PHP-version-of-my-site-"><strong>instructions</strong></a> on how to update the PHP version you use.</li>
 </ul>
 <div class="alert alert-important">
@@ -11,7 +11,7 @@
 </div>
 <h2>Dedicated Non-Admin Nginx users</h2>
 <ul>
-<li>Non-Admin Nginx users were automatically updated to PHP 5.6 on March 14 2017.</li>
+<li>Non-Admin Nginx users were not updated.</li>
 </ul>
 <div class="alert alert-important">
 <div class="alert-icon"><img src="http://objects-us-west-1.dream.io/kbimages/images/dh-kb-important-icon.svg" alt="" width="60" height="60" /></div>


### PR DESCRIPTION
This article looks to have been an innocent victim of mass updates related to the PHP 5.5 EOL. nginx only offers PHP 5.5, so in my opinion this article should reflect that (until such time as managed nginx is either completely removed or updated to PHP 5.6).