### PR TITLE
Update How to Configure Apache on DreamCompute Running Fedora or Cent…

### DIFF
--- a/How to Configure Apache on DreamCompute Running Fedora or CentOS.html
+++ b/How to Configure Apache on DreamCompute Running Fedora or CentOS.html
@@ -14,7 +14,7 @@ they have their own specific configuration and file hierarchy.</p>
 <div id="installing-apache">
 <h2>Installing Apache</h2>
 <p>To install Apache on your system, run the following command:</p>
-<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[root@server]#</span> yum install httpd
+<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[user@server]$</span> sudo yum install httpd
 </pre></div>
 </div>
 <ul class="simple">
@@ -23,7 +23,7 @@ dependency packages needed for Apache.</li>
 <li>Enter “<strong>y</strong>” and hit enter to confirm.</li>
 </ul>
 <p>In order to start Apache run</p>
-<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[root@server]#</span> service httpd start
+<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[user@server]$</span> sudo service httpd start
 </pre></div>
 </div>
 <p>This may display an error about the lack of a configuration, but it
@@ -35,7 +35,7 @@ httpd: Could not reliably determine the server's fully qualified domain name, us
 </div>
 <p>You likely want apache to start on boot, and this can be configured
 with:</p>
-<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[root@server]#</span> chkconfig httpd on
+<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[user@server]$</span> sudo chkconfig httpd on
 </pre></div>
 </div>
 <p>If you visit the public IP in your browser for your DreamCompute
@@ -62,7 +62,7 @@ working properly.
 <p>This directory contains all the configuration files for your Apache
 server, and symlinks to other parts of the Apache install such as the
 logs and modules directories.</p>
-<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[root@server]#</span> ls /etc/httpd
+<div class="highlight-console"><div class="highlight"><pre><span></span><span class="gp">[user@server]$</span> ls /etc/httpd
 <span class="go">conf  conf.d  conf.modules.d  logs  modules  run</span>
 </pre></div>
 </div>


### PR DESCRIPTION
…OS.html

While the "How to Configure Apache on DreamCompute Running Debian or Ubuntu" article lists all commands with a sudo prefix, this one mysteriously did not (it instead vaguely indicated that you needed to already be the root user before running the commands). Since I just had a customer express major confusion about being unable to run the commands without sudo, I'd like this article to match it's Debian/Ubuntu counterpart.